### PR TITLE
even better fix for the wrong args number for getScratchValue

### DIFF
--- a/src/Anime.js
+++ b/src/Anime.js
@@ -56,7 +56,7 @@ class Anime extends MC.TimedIncident {
     });
   }
 
-  getScratchValue(id, attr) {
+  getScratchValue(attr) {
     if (this.channel.compoAttributes.hasOwnProperty(attr)) {
       const obj = {};
       const compoAttribute = this.channel.compoAttributes[attr];


### PR DESCRIPTION
There is a bug on Anime. The method getScratchValue is called with wrong number of parameters causing unexpected bahaviour.